### PR TITLE
Create continuous integration for tests via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+language: python
+python:
+   - "3.5"
 before_install:
 - "sudo apt-get update && sudo apt-get install --no-install-recommends \
    texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra \
-   texlive-latex-recommended dvipng python-pytest"
+   texlive-latex-recommended dvipng"
 script:
 - cd literature && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+before_install:
+- "sudo apt-get update && sudo apt-get install --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra texlive-latex-recommended dvipng"
+script:
+- cd tests && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 before_install:
-- "sudo apt-get update && sudo apt-get install --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra texlive-latex-recommended dvipng"
+- "sudo apt-get update && sudo apt-get install --no-install-recommends \
+   texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra \
+   texlive-latex-recommended dvipng python-pytest"
 script:
-- cd tests && make
+- cd literature && make test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/fangohr/testing-in-science-1.svg?branch=master)](https://travis-ci.org/fangohr/testing-in-science-1)
+
 # Repository of WSSSPE Working group on software testing in computational science
 
 Initial thoughts from [WSSSPE 4


### PR DESCRIPTION
The tests attempt to build a pdf file based on the entries in the BibTeX file, by compiling a LaTeX document. This is a simple but maybe practical way of testing the syntax of the BibTeX file, and could be later expanded to build pdfs of interest automatically. 

This pull request provides automatic execution of these tests via Travis, so that we notice more easily if an addition breaks the file.
